### PR TITLE
Fix how order_stock_reduced flag is set and read in WC 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Note that is not necessary any kind of configuration.
 
 ## Changelog ##
 
+### 1.0.2 - 2017/06/05 ###
+
+- Fixed order_stock_reduced flag for WooCommerce 3.0.7 to prevent duplicate reductions and enable stock increase when the order is cancelled after stock reduction.
+
 ### 1.0.1 - 2017/01/08 ###
 
 - Fixed how reduce order when using the order quick action buttons.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reduce-stock-of-manual-orders-for-woocommerce",
   "description": "Automatically reduce or increase stock levels of manual orders in WooCommerce.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/claudiosanches/reduce-stock-of-manual-orders-for-woocommerce.git"

--- a/readme.txt
+++ b/readme.txt
@@ -41,6 +41,10 @@ Note that is not necessary any kind of configuration.
 
 == Changelog ==
 
+= 1.0.2 - 2017/06/05 =
+
+- Fixed order_stock_reduced flag for WooCommerce 3.0.7 to prevent duplicate reductions and enable stock increase when the order is cancelled after stock reduction.
+
 = 1.0.1 - 2017/01/08 =
 
 - Fixed how reduce order when using the order quick action buttons.


### PR DESCRIPTION
This fixes #2 and another more serious bug: stock reductions are done again and again every time the order is saved in WooCommerce 3.